### PR TITLE
Added trestle dashboards and trestle-auth gem for protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,6 @@ gem "stackprof"
 gem "devise", "~> 4.9", ">= 4.9.3"
 
 gem "tailwindcss-rails", "~> 4.3"
+
+gem 'trestle'
+gem 'trestle-auth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,18 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.13.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -332,6 +344,14 @@ GEM
     tailwindcss-ruby (4.1.11-x86_64-linux-musl)
     thor (1.3.2)
     timeout (0.4.3)
+    trestle (0.10.1)
+      activemodel (>= 6.0.0)
+      kaminari (>= 1.1.0)
+      railties (>= 6.0.0)
+      turbo-rails (>= 2.0.6)
+    trestle-auth (0.5.0)
+      bcrypt (~> 3.1.7)
+      trestle (~> 0.10.0)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
@@ -393,6 +413,8 @@ DEPENDENCIES
   standard-rails
   stimulus-rails
   tailwindcss-rails (~> 4.3)
+  trestle
+  trestle-auth
   turbo-rails
   tzinfo-data
   web-console

--- a/app/admin/auth/account_admin.rb
+++ b/app/admin/auth/account_admin.rb
@@ -1,0 +1,38 @@
+Trestle.resource(:account, model: User, scope: Auth, singular: true) do
+  instance do
+    current_user
+  end
+
+  remove_action :new, :edit, :destroy
+
+  form do |user|
+    text_field :email
+
+    row do
+      col(sm: 6) { password_field :password }
+      col(sm: 6) { password_field :password_confirmation }
+    end
+  end
+
+  # Ignore the password parameters if they are blank
+  update_instance do |instance, attrs|
+    if attrs[:password].blank?
+      attrs.delete(:password)
+      attrs.delete(:password_confirmation) if attrs[:password_confirmation].blank?
+    end
+
+    instance.assign_attributes(attrs)
+  end
+
+  # Log the current user back in if their password was changed
+  after_action on: :update do
+    if instance.encrypted_password_previously_changed?
+      login!(instance)
+    end
+  end if Devise.sign_in_after_reset_password
+
+  # Limit the parameters that are permitted to be updated by the user
+  params do |params|
+    params.require(:account).permit(:email, :password, :password_confirmation)
+  end
+end

--- a/app/admin/auth/users_admin.rb
+++ b/app/admin/auth/users_admin.rb
@@ -1,0 +1,43 @@
+Trestle.resource(:users, model: User, scope: Auth) do
+  menu do
+    group :configuration, priority: :last do
+      item :users, icon: "fas fa-users"
+    end
+  end
+
+  table do
+    column :avatar, header: false do |user|
+      avatar_for(user)
+    end
+    column :email, link: true
+    actions do |a|
+      a.delete unless a.instance == current_user
+    end
+  end
+
+  form do |user|
+    text_field :email
+
+    row do
+      col(sm: 6) { password_field :password }
+      col(sm: 6) { password_field :password_confirmation }
+    end
+  end
+
+  # Ignore the password parameters if they are blank
+  update_instance do |instance, attrs|
+    if attrs[:password].blank?
+      attrs.delete(:password)
+      attrs.delete(:password_confirmation) if attrs[:password_confirmation].blank?
+    end
+
+    instance.assign_attributes(attrs)
+  end
+
+  # Log the current user back in if their password was changed
+  after_action on: :update do
+    if instance == current_user && instance.encrypted_password_previously_changed?
+      login!(instance)
+    end
+  end if Devise.sign_in_after_reset_password
+end

--- a/app/admin/users_admin.rb
+++ b/app/admin/users_admin.rb
@@ -1,0 +1,35 @@
+Trestle.resource(:users) do
+  menu do
+    item :users, icon: "fa fa-star"
+  end
+
+  # Customize the table columns shown on the index view.
+  #
+  # table do
+  #   column :name
+  #   column :created_at, align: :center
+  #   actions
+  # end
+
+  # Customize the form fields shown on the new/edit views.
+  #
+  # form do |user|
+  #   text_field :name
+  #
+  #   row do
+  #     col { datetime_field :updated_at }
+  #     col { datetime_field :created_at }
+  #   end
+  # end
+
+  # By default, all parameters passed to the update and create actions will be
+  # permitted. If you do not have full trust in your users, you should explicitly
+  # define the list of permitted parameters.
+  #
+  # For further information, see the Rails documentation on Strong Parameters:
+  #   http://guides.rubyonrails.org/action_controller_overview.html#strong-parameters
+  #
+  # params do |params|
+  #   params.require(:user).permit(:name, ...)
+  # end
+end

--- a/app/assets/javascripts/trestle/custom.js
+++ b/app/assets/javascripts/trestle/custom.js
@@ -1,0 +1,7 @@
+// This file may be used for providing additional customizations to the Trestle
+// admin. It will be automatically included within all admin pages.
+//
+// For organizational purposes, you may wish to define your customizations
+// within individual partials and `require` them here.
+//
+//  e.g. //= require "trestle/custom/my_custom_js"

--- a/app/assets/stylesheets/trestle/_custom.css
+++ b/app/assets/stylesheets/trestle/_custom.css
@@ -1,0 +1,8 @@
+/* This file may be used for providing additional customizations to the Trestle
+ * admin. It will be automatically included within all admin pages.
+ *
+ * For organizational purposes, you may wish to define your customizations
+ * within individual partials in this folder and they'll be required below.
+ *
+ *= require_tree .
+*/

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
     :recoverable, :rememberable, :validatable
 
   before_validation :assign_university_from_email, on: :create
+  after_initialize :set_default_admin, if: :new_record?
 
   def assign_university_from_email
     return if email.blank?
@@ -20,5 +21,11 @@ class User < ApplicationRecord
     end
 
     self.university = match["name"] if match
+  end
+
+  private
+
+  def set_default_admin
+    self.is_admin ||= false
   end
 end

--- a/config/initializers/trestle.rb
+++ b/config/initializers/trestle.rb
@@ -1,0 +1,230 @@
+Trestle.configure do |config|
+  # == Customization Options
+  #
+  # Set the page title shown in the main header within the admin.
+  #
+  config.site_title = "App"
+
+  # Specify a custom image to be used in place of the site title for mobile and
+  # expanded/desktop navigation. These images should be placed within your
+  # asset paths, e.g. app/assets/images.
+  #
+  # config.site_logo = "logo.png"
+
+  # Specify a custom image to be used for the collapsed/tablet navigation.
+  #
+  # config.site_logo_small = "logo-small.png"
+
+  # Define primary and secondary theme colors. Color values may be specified
+  # as either 3- or 6-digit hex codes, or rgb/hsl() triplets.
+  #
+  # config.theme = { primary: "#338ab7", secondary: "#719dc3" }
+
+  # Specify a favicon to be used within the admin.
+  #
+  # config.favicon = "favicon.ico"
+
+  # Set the text shown in the page footer within the admin.
+  # Defaults to 'Powered by Trestle'.
+  #
+  # config.footer = "Powered by Trestle"
+
+  # Sets the default precision for timestamps (either :minutes or :seconds).
+  # Defaults to :minutes.
+  #
+  # config.timestamp_precision = :minutes
+
+  # == Mounting Options
+  #
+  # Set the path at which to mount the Trestle admin. Defaults to /admin.
+  #
+  # config.path = "/admin"
+
+  # Toggle whether Trestle should automatically mount the admin within your
+  # Rails application's routes. Defaults to true.
+  #
+  # config.automount = false
+
+  # == Navigation Options
+  #
+  # Set the path to consider the application root (for title links and breadcrumbs).
+  # Defaults to the same value as `config.path`.
+  #
+  # config.root = "/"
+
+  # Set the initial breadcrumbs to display in the breadcrumb trail.
+  # Defaults to a breadcrumb labeled 'Home' linking to to the application root.
+  #
+  # config.root_breadcrumbs = -> { [Trestle::Breadcrumb.new("Home", Trestle.config.root)] }
+
+  # Set the default icon class to use when it is not explicitly provided.
+  # Defaults to "fa fa-arrow-circle-o-right".
+  #
+  # config.default_navigation_icon = "fa fa-arrow-circle-o-right"
+
+  # Add an explicit menu block to be added to the admin navigation.
+  #
+  # config.menu do
+  #   group "Custom Group" do
+  #     item "Custom Link", "/admin/custom", icon: "fa fa-car", badge: { text: "NEW!", class: "label-success" }, priority: :first
+  #   end
+  # end
+
+  # == Extension Options
+  #
+  # Specify helper modules to expose to the admin.
+  #
+  # config.helper :all
+  # config.helper -> { CustomHelper }
+
+  # Register callbacks to run before, after or around all Trestle actions.
+  #
+  # config.before_action do |controller|
+  #   Rails.logger.debug("Before action")
+  # end
+  #
+  # config.after_action do |controller|
+  #   Rails.logger.debug("After action")
+  # end
+  #
+  # config.around_action do |controller, block|
+  #   Rails.logger.debug("Around action (before)")
+  #   block.call
+  #   Rails.logger.debug("Around action (after)")
+  # end
+
+  # Specify a custom hook to be injected into the admin.
+  #
+  # config.hook(:stylesheets) do
+  #   stylesheet_link_tag "custom"
+  # end
+
+  # Specify the parameters that should persist across requests when
+  # paginating or reordering. Defaults to [:sort, :order, :scope].
+  #
+  # config.persistent_params << :query
+
+  # List of methods to try calling on an instance when displayed by the `display` helper.
+  # Defaults to [:display_name, :full_name, :name, :title, :username, :login, :email].
+  #
+  # config.display_methods.unshift(:admin_label)
+
+  # Customize the default adapter class used by all admin resources.
+  # See the documentation on Trestle::Adapters::Adapter for details on
+  # the adapter methods that can be customized.
+  #
+  # config.default_adapter = Trestle::Adapters.compose(Trestle::Adapters::SequelAdapter)
+  # config.default_adapter.include MyAdapterExtensions
+
+  # Register a form field type to be made available to the Trestle form builder.
+  # Field types should conform to the following method definition:
+  #
+  # class CustomFormField
+  #   def initialize(builder, template, name, options={}, &block); end
+  #   def render; end
+  # end
+  #
+  # config.form_field :custom, -> { CustomFormField }
+
+  # == Debugging Options
+  #
+  # Enable debugging of form errors. Defaults to true in development mode.
+  #
+  # config.debug_form_errors = true
+
+  # == Authentication Options
+  #
+  # Set the authentication backend to use Devise.
+  #
+  config.auth.backend = :devise
+
+  # Specify the Devise/Warden mapping/scope.
+  #
+  config.auth.warden.scope = :user
+
+  # Specify the user class to be used by trestle-auth.
+  #
+  config.auth.user_class = -> { User }
+
+  # Specify the Trestle admin for managing the current user (My Account).
+  #
+  config.auth.user_admin = -> { :"auth/account" }
+
+  # Specify the parameter (along with a password) to be used to
+  # authenticate an administrator. Defaults to :email if not specified below.
+  #
+  config.auth.authenticate_with = -> { Devise.authentication_keys.first }
+
+  # Customize the rendering of user avatars. Can be disabled by setting to false.
+  # Defaults to the Gravatar based on the user's email address.
+  #
+  # config.auth.avatar = ->(user) {
+  #   avatar(fallback: user.initials) do
+  #     image_tag(user.avatar_url, alt: user.name) if user.avatar_url?
+  #   end
+  # }
+
+  # Customize the rendering of the current user's name in the main header.
+  # Defaults to the user's #first_name and #last_name (last name in bold),
+  # with a fallback to `display(user)` if those methods aren't defined.
+  #
+  # config.auth.format_user_name = ->(user) {
+  #   content_tag(:strong, user.full_name)
+  # }
+
+  # Customize the method for determining the user's locale.
+  # Defaults to user.locale (if the method is defined).
+  #
+  # config.auth.locale = ->(user) {
+  #   user.locale if user.respond_to?(:locale)
+  # }
+
+  # Customize the method for determining the user's time zone.
+  # Defaults to user.time_zone (if the method is defined).
+  #
+  # config.auth.time_zone = ->(user) {
+  #   user.time_zone if user.respond_to?(:time_zone)
+  # }
+
+  # Specify the redirect location after a successful login.
+  # Defaults to the main Trestle admin path.
+  #
+  config.auth.redirect_on_login = -> { "/admin" }
+
+  # Specify the redirect location after logging out.
+  # Defaults to the trestle-auth new login path.
+  #
+  config.auth.redirect_on_logout = -> { "/users/sign_in" }
+
+  # Enable or disable the built-in login/logout form and actions. Defaults to true.
+  # You may wish to disable these if you are using a custom backend and
+  # handling authentication entirely within your main application.
+  #
+  # config.auth.enable_login = true
+  # config.auth.enable_logout = true
+
+  # Specify the path to redirect to when login is required.
+  # Defaults to the trestle-auth login page. You may wish to change
+  # this if you have also disabled the login form/action above.
+  #
+  config.auth.login_url = -> { "/users/sign_in" }
+
+  # Specify the logo used on the login form.
+  # If not specified, will fall back to config.site_logo,
+  # config.site_logo_small or config.site_title.
+  #
+  # config.auth.logo = "auth-logo.png"
+
+  # Enable or disable remember me functionality. Defaults to true.
+  #
+  # config.auth.remember.enabled = false
+
+  # Ensure only admins can access the admin dashboard
+  config.before_action do |controller|
+    unless controller.current_user&.is_admin
+      flash[:alert] = "You are not authorized to access the admin dashboard."
+      controller.redirect_to main_app.root_path
+    end
+  end
+
+end

--- a/db/migrate/20250723185728_add_is_admin_to_user.rb
+++ b/db/migrate/20250723185728_add_is_admin_to_user.rb
@@ -1,0 +1,5 @@
+class AddIsAdminToUser < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :is_admin, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_21_065122) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_23_185728) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -53,6 +53,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_21_065122) do
     t.string "name"
     t.string "university"
     t.text "profile_bio"
+    t.boolean "is_admin"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
This pull request introduces the Trestle admin framework to the application, adds administrative features, and enhances user management. Key changes include adding Trestle gems, configuring Trestle, defining admin resources, and introducing an `is_admin` attribute to the `User` model for role-based access control.

### Trestle Integration and Configuration:
* Added `trestle` and `trestle-auth` gems to the `Gemfile` to integrate the Trestle admin framework. (`Gemfile`, [GemfileR63-R65](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR63-R65))
* Created `config/initializers/trestle.rb` to configure Trestle, including authentication with Devise, admin access restrictions, and customizations for site title, navigation, and login/logout behavior. (`config/initializers/trestle.rb`, [config/initializers/trestle.rbR1-R230](diffhunk://#diff-8943a9253eb8fd9f896c2b8777a7e5ab94a38cc3fccdb812f07f12eacf29777aR1-R230))

### Admin Resource Definitions:
* Added `app/admin/auth/account_admin.rb` to manage the current user's account, including updating email and password with validation and Devise integration. (`app/admin/auth/account_admin.rb`, [app/admin/auth/account_admin.rbR1-R38](diffhunk://#diff-5d52f1e08388a583d8269b92eeae719406a8bccaf392659d68c6ae4984264314R1-R38))
* Added `app/admin/auth/users_admin.rb` to manage users, including listing users, editing user details, and restricting delete actions for the current user. (`app/admin/auth/users_admin.rb`, [app/admin/auth/users_admin.rbR1-R43](diffhunk://#diff-6b9ed1dd434d7b4cc9348ee580923208215c280243dead29f8f6e1eff3e61b31R1-R43))
* Added a placeholder `app/admin/users_admin.rb` for general user management, with commented-out examples for customization. (`app/admin/users_admin.rb`, [app/admin/users_admin.rbR1-R35](diffhunk://#diff-36c497a0cdabbd7eebd00567712d0db41966d8eb17980fb448d4b80a86f4ef33R1-R35))

### User Model Enhancements:
* Added an `is_admin` boolean attribute to the `User` model to distinguish administrators. (`db/migrate/20250723185728_add_is_admin_to_user.rb`, [[1]](diffhunk://#diff-96491dd159362f368997ccbb59eed4ebc5e48d987a31b16c1993f42967cbf0d0R1-R5); `db/schema.rb`, [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R56)
* Introduced a `set_default_admin` method in `User` to ensure new users default to non-admin unless specified. (`app/models/user.rb`, [[1]](diffhunk://#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bR11) [[2]](diffhunk://#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bR25-R30)


Closes #43 